### PR TITLE
Add arm64_32 watchOS arch

### DIFF
--- a/UniversalFramework_Base.xcconfig
+++ b/UniversalFramework_Base.xcconfig
@@ -10,7 +10,7 @@ SUPPORTED_PLATFORMS                    = macosx iphonesimulator iphoneos watchos
 VALID_ARCHS[sdk=macosx*]               = i386 x86_64
 VALID_ARCHS[sdk=iphoneos*]             = arm64 armv7 armv7s
 VALID_ARCHS[sdk=iphonesimulator*]      = i386 x86_64
-VALID_ARCHS[sdk=watchos*]              = armv7k
+VALID_ARCHS[sdk=watchos*]              = armv7k arm64_32
 VALID_ARCHS[sdk=watchsimulator*]       = i386
 VALID_ARCHS[sdk=appletvos*]            = arm64
 VALID_ARCHS[sdk=appletvsimulator*]     = x86_64


### PR DESCRIPTION
Previously, this architecture was missing. This caused a watchOS target with a universal framework dependency to not build the dependency when building for a `Generic watchOS Device`. It would work fine building for the `watchsimulator` making it even weirder to track down.