### PR TITLE
Add arm64 for macOS

### DIFF
--- a/UniversalFramework_Base.xcconfig
+++ b/UniversalFramework_Base.xcconfig
@@ -7,13 +7,13 @@
 
 // Make it universal
 SUPPORTED_PLATFORMS                    = macosx iphonesimulator iphoneos watchos watchsimulator appletvos appletvsimulator
-VALID_ARCHS[sdk=macosx*]               = i386 x86_64 arm64
-VALID_ARCHS[sdk=iphoneos*]             = arm64 armv7 armv7s
-VALID_ARCHS[sdk=iphonesimulator*]      = i386 x86_64
+VALID_ARCHS[sdk=macosx*]               = i386 x86_64 arm64 arm64e
+VALID_ARCHS[sdk=iphoneos*]             = arm64 arm64e armv7 armv7s
+VALID_ARCHS[sdk=iphonesimulator*]      = i386 x86_64 arm64 arm64e
 VALID_ARCHS[sdk=watchos*]              = armv7k arm64_32
 VALID_ARCHS[sdk=watchsimulator*]       = i386
-VALID_ARCHS[sdk=appletvos*]            = arm64
-VALID_ARCHS[sdk=appletvsimulator*]     = x86_64
+VALID_ARCHS[sdk=appletvos*]            = arm64 arm64e
+VALID_ARCHS[sdk=appletvsimulator*]     = x86_64 arm64 arm64e
 
 // Dynamic linking uses different default copy paths
 LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]           = $(inherited) '@executable_path/../Frameworks' '@loader_path/Frameworks'

--- a/UniversalFramework_Base.xcconfig
+++ b/UniversalFramework_Base.xcconfig
@@ -11,7 +11,7 @@ VALID_ARCHS[sdk=macosx*]               = i386 x86_64 arm64 arm64e
 VALID_ARCHS[sdk=iphoneos*]             = arm64 arm64e armv7 armv7s
 VALID_ARCHS[sdk=iphonesimulator*]      = i386 x86_64 arm64 arm64e
 VALID_ARCHS[sdk=watchos*]              = armv7k arm64_32
-VALID_ARCHS[sdk=watchsimulator*]       = i386
+VALID_ARCHS[sdk=watchsimulator*]       = i386 arm64
 VALID_ARCHS[sdk=appletvos*]            = arm64 arm64e
 VALID_ARCHS[sdk=appletvsimulator*]     = x86_64 arm64 arm64e
 

--- a/UniversalFramework_Base.xcconfig
+++ b/UniversalFramework_Base.xcconfig
@@ -7,7 +7,7 @@
 
 // Make it universal
 SUPPORTED_PLATFORMS                    = macosx iphonesimulator iphoneos watchos watchsimulator appletvos appletvsimulator
-VALID_ARCHS[sdk=macosx*]               = i386 x86_64
+VALID_ARCHS[sdk=macosx*]               = i386 x86_64 arm64
 VALID_ARCHS[sdk=iphoneos*]             = arm64 armv7 armv7s
 VALID_ARCHS[sdk=iphonesimulator*]      = i386 x86_64
 VALID_ARCHS[sdk=watchos*]              = armv7k arm64_32


### PR DESCRIPTION
This makes it possible to support Apple Silicon builds on macOS.

I've tried this out, and it appears to be all you need. The change appears to be backwards-compatible as well. Older Xcode versions don't mind this being here.